### PR TITLE
Fix docblocks Ref

### DIFF
--- a/jsonnet_docblock_parser/generator.py
+++ b/jsonnet_docblock_parser/generator.py
@@ -17,7 +17,7 @@ class Generator:
     }
 
     # This results array contains all docblocks found in the file.
-    for docblock in results:
+    for docblock in results["docblocks"]:
       output["docblocks"].append(docblock.render())
 
     return json.dumps(output, indent=4)


### PR DESCRIPTION
Hey there, I was getting this error attempting to use version 0.1.3:

```
AttributeError: 'str' object has no attribute 'render'
```

This change seems to resolve the issue.